### PR TITLE
Deprecated config options in Debian 9 Stretch

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -59,8 +59,8 @@
 {{ option_default_uncommented('UsePrivilegeSeparation', 'yes') }}
 
 # Lifetime and size of ephemeral version 1 server key
-{{ option_default_uncommented('KeyRegenerationInterval', 3600) }}
-{{ option_default_uncommented('ServerKeyBits', 1024) }}
+{{ option('KeyRegenerationInterval', 3600) }}
+{{ option('ServerKeyBits', 1024) }}
 
 # Logging
 {{ option_default_uncommented('SyslogFacility', 'AUTH') }}
@@ -72,14 +72,14 @@
 {{ option_default_uncommented('StrictModes', 'yes') }}
 
 {{ option('DSAAuthentication', 'yes') }}
-{{ option_default_uncommented('RSAAuthentication', 'yes') }}
+{{ option('RSAAuthentication', 'yes') }}
 {{ option_default_uncommented('PubkeyAuthentication', 'yes') }}
 {{ option('AuthorizedKeysFile', '%h/.ssh/authorized_keys') }}
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 {{ option_default_uncommented('IgnoreRhosts', 'yes') }}
 # For this to work you will also need host keys in /etc/ssh_known_hosts
-{{ option_default_uncommented('RhostsRSAAuthentication', 'no') }}
+{{ option('RhostsRSAAuthentication', 'no') }}
 # similar for protocol version 2
 {{ option_default_uncommented('HostbasedAuthentication', 'no') }}
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication


### PR DESCRIPTION
Comment/remove configuration options that were deprecated in OpenSSH 7.4 and Debian 9 (Stretch) for security reasons. Prior to removing these options, the following error messages were appearing in /var/log/auth.log every time an SSH session was opened.

/etc/ssh/sshd_config line 22: Deprecated option KeyRegenerationInterval
/etc/ssh/sshd_config line 23: Deprecated option ServerKeyBits
/etc/ssh/sshd_config line 35: Deprecated option RSAAuthentication
/etc/ssh/sshd_config line 42: Deprecated option RhostsRSAAuthentication

Disabling the option was not sufficient. Each item must be commented/removed to suppress the "Deprecated option" messages.